### PR TITLE
Abstract out and move PAGE_URL to env, rather than hard-coding it

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,9 +20,10 @@ pipeline {
       environment {
         WEB_PAGE_TEST = credentials('WEB_PAGE_TEST')
         WEBPAGETEST_SERVER = "https://${WEB_PAGE_TEST}@wpt-api.stage.mozaws.net/"
+        PAGE_URL = "https://latest.dev.lcip.org/?service=sync&entrypoint=firstrun&context=fx_desktop_v3"
       }
       steps {
-          sh '/usr/src/app/bin/webpagetest test "https://latest.dev.lcip.org/?service=sync&entrypoint=firstrun&context=fx_desktop_v3" -l "us-east-1:Firefox" -r 9 --first --poll --reporter json > fxa-homepage.json'
+          sh '/usr/src/app/bin/webpagetest test "${PAGE_URL}" -l "us-east-1:Firefox" -r 9 --first --poll --reporter json > fxa-homepage.json'
       }
       post {
         always {


### PR DESCRIPTION
This is temporary, and we'll work out the best config option for passing in multiple URLs, later.

For now, this fix for https://github.com/mozilla/wpt-api/issues/6 is slightly cleaner, and makes the command-line easier to read/manage, etc.

Passing ad-hoc here: https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/wpt-api.fxa-perf/73/console and here: https://gist.github.com/stephendonner/8d35f62cfd56c5e099adc1211e8ed303

@philbooth @davehunt @soulgalore r?