### PR TITLE
Use jq to filter out desired perf metrics from JSON-results file

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,15 +23,20 @@ pipeline {
         PAGE_URL = "https://latest.dev.lcip.org/?service=sync&entrypoint=firstrun&context=fx_desktop_v3"
       }
       steps {
-        sh """
-          /usr/src/app/bin/webpagetest test "${PAGE_URL}" -l "us-east-1:Firefox" -r 9 --first --poll --reporter json > fxa-homepage.json
-          docker run --mount type=bind,source="${PWD}",target=/data realguess/jq jq '.data.runs."1".firstView.TTFB' data/fxa-homepage.json
-        """
+        sh '/usr/src/app/bin/webpagetest test "${PAGE_URL}" -l "us-east-1:Firefox" -r 9 --first --poll --reporter json > fxa-homepage.json'
       }
       post {
         always {
           archiveArtifacts 'fxa-homepage.json'
         }
+      }
+    }
+    stage('filter') {
+      agent {
+        docker { image 'realguess/jq' }
+      }
+      steps {
+        sh 'docker run realguess/jq jq '.data.runs."1".firstView.TTFB' data/fxa-homepage.json'
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,11 @@
 
 pipeline {
   agent none
+  environment {
+    WEB_PAGE_TEST = credentials('WEB_PAGE_TEST')
+    WEBPAGETEST_SERVER = "https://${WEB_PAGE_TEST}@wpt-api.stage.mozaws.net/"
+    PAGE_URL = "https://latest.dev.lcip.org/?service=sync&entrypoint=firstrun&context=fx_desktop_v3"
+  }
   stages {
     stage('clone') {
        agent any
@@ -17,11 +22,6 @@ pipeline {
       agent {
         dockerfile { dir 'webpagetest-api' }
       }
-      environment {
-        WEB_PAGE_TEST = credentials('WEB_PAGE_TEST')
-        WEBPAGETEST_SERVER = "https://${WEB_PAGE_TEST}@wpt-api.stage.mozaws.net/"
-        PAGE_URL = "https://latest.dev.lcip.org/?service=sync&entrypoint=firstrun&context=fx_desktop_v3"
-      }
       steps {
         sh '/usr/src/app/bin/webpagetest test "${PAGE_URL}" -l "us-east-1:Firefox" -r 9 --first --poll --reporter json > fxa-homepage.json'
       }
@@ -33,10 +33,10 @@ pipeline {
     }
     stage('filter') {
       agent {
-        docker { image 'realguess/jq' }
+        docker { image 'colstrom/jq' }
       }
       steps {
-        sh 'docker run realguess/jq jq '.data.runs."1".firstView.TTFB' data/fxa-homepage.json'
+        sh 'jq ".data.runs."1".firstView.TTFB" data/fxa-homepage.json'
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
         docker { image 'colstrom/jq' }
       }
       steps {
-        sh 'jq ".data.runs."1".firstView.TTFB" data/fxa-homepage.json'
+        sh 'jq ".data.runs.\'1'.firstView.TTFB" data/fxa-homepage.json'
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
         docker { image 'colstrom/jq' }
       }
       steps {
-        sh 'jq ".data.runs.\'1'.firstView.TTFB" data/fxa-homepage.json'
+        sh "jq '.data.runs.\"1".firstView.TTFB' data/fxa-homepage.json"
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,8 +23,10 @@ pipeline {
         PAGE_URL = "https://latest.dev.lcip.org/?service=sync&entrypoint=firstrun&context=fx_desktop_v3"
       }
       steps {
-          sh '/usr/src/app/bin/webpagetest test "${PAGE_URL}" -l "us-east-1:Firefox" -r 9 --first --poll --reporter json > fxa-homepage.json'
-          sh 'docker run --mount type=bind,source="${PWD}",target=/data realguess/jq jq '.data.runs."1".firstView.TTFB' data/fxa-homepage.json'
+        sh """
+          /usr/src/app/bin/webpagetest test "${PAGE_URL}" -l "us-east-1:Firefox" -r 9 --first --poll --reporter json > fxa-homepage.json
+          docker run --mount type=bind,source="${PWD}",target=/data realguess/jq jq '.data.runs."1".firstView.TTFB' data/fxa-homepage.json
+        """
       }
       post {
         always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,7 @@ pipeline {
       }
       steps {
           sh '/usr/src/app/bin/webpagetest test "${PAGE_URL}" -l "us-east-1:Firefox" -r 9 --first --poll --reporter json > fxa-homepage.json'
+          sh 'docker run --mount type=bind,source="${PWD}",target=/data realguess/jq jq '.data.runs."1".firstView.TTFB' data/fxa-homepage.json
       }
       post {
         always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
       }
       steps {
           sh '/usr/src/app/bin/webpagetest test "${PAGE_URL}" -l "us-east-1:Firefox" -r 9 --first --poll --reporter json > fxa-homepage.json'
-          sh 'docker run --mount type=bind,source="${PWD}",target=/data realguess/jq jq '.data.runs."1".firstView.TTFB' data/fxa-homepage.json
+          sh 'docker run --mount type=bind,source="${PWD}",target=/data realguess/jq jq '.data.runs."1".firstView.TTFB' data/fxa-homepage.json'
       }
       post {
         always {


### PR DESCRIPTION
This lays the ground work for https://github.com/mozilla/wpt-api/issues/5

Passing ad-hoc here: https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/wpt-api.fxa-perf.adhoc/33/

I still need to write out and archive ```stats.json``` or whatever we're going to (temporarily) call the new, output perf-metrics file.