### PR TITLE
Remove TTIMeasurementEnd, which is Chrome-only, and null in Firefox

### DIFF
--- a/jq-filter.txt
+++ b/jq-filter.txt
@@ -1,7 +1,6 @@
 .data.runs."1".firstView.TTFB,
 .data.runs."1".firstView.firstPaint,
 .data.runs."1".firstView.SpeedIndex,
-.data.runs."1".firstView.TTIMeasurementEnd,
 .data.runs."1".firstView.bytesInDoc,
 .data.runs."1".firstView.fullyLoaded,
 .data.runs."1".firstView.requestsFull


### PR DESCRIPTION
@philbooth r?