### PR TITLE
Partially fixes Issue 16 - send filtered perf metrics over to DataDog via statsd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
-FROM ubuntu:xenial
+FROM python:3
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update && apt-get install -y  python 3.6 python3-pip \
-    && rm -rf /var/lib/apt/lists/*
+ADD send_to_datadog.py /
 
 RUN pip3 install datadog
 
 # RUN iptables -t nat -A DOCKER -p udp --dport 8125 -j DNAT --to-destination 34.197.24.237:8125
 
-CMD python send_to_datadog.py
+CMD [ "python", "./send_to_datadog.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get update && apt-get install -y  python 3.6 python3-pip \
 
 RUN pip3 install datadog
 
-RUN iptables -t nat -A DOCKER -p udp --dport 8125 -j DNAT --to-destination 34.197.24.237:8125
+# RUN iptables -t nat -A DOCKER -p udp --dport 8125 -j DNAT --to-destination 34.197.24.237:8125
 
 CMD python send_to_datadog.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get update && apt-get install -y  python 3.6 python3-pip \
 
 RUN pip3 install datadog
 
-CMD python send_to_datadog.py
+iptables -t nat -A DOCKER -p udp --dport 8125 -j DNAT --to-destination 34.197.24.237:8125
 
-RUN netstat | grep "8125"
+CMD python send_to_datadog.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get update && apt-get install -y  python 3.6 python3-pip \
 
 RUN pip3 install datadog
 
-sudo iptables -t nat -A DOCKER -p udp --dport 8125 -j DNAT --to-destination 34.197.24.237:8125
+RUN sudo iptables -t nat -A DOCKER -p udp --dport 8125 -j DNAT --to-destination 34.197.24.237:8125
 
 CMD python send_to_datadog.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,6 @@ FROM python:2-alpine3.7
 RUN pip install pipenv
 RUN pipenv install datadog
 
+RUN pipenv shell
+
 CMD python send_to_datadog.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get update && apt-get install -y  python 3.6 python3-pip \
 
 RUN pip3 install datadog
 
-RUN sudo iptables -t nat -A DOCKER -p udp --dport 8125 -j DNAT --to-destination 34.197.24.237:8125
+RUN iptables -t nat -A DOCKER -p udp --dport 8125 -j DNAT --to-destination 34.197.24.237:8125
 
 CMD python send_to_datadog.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@ FROM ubuntu:xenial
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN pip install datadog
+RUN apt-get update && apt-get install -y  python 3.6 python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install datadog
 
 CMD python send_to_datadog.py
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get update && apt-get install -y  python 3.6 python3-pip \
 
 RUN pip3 install datadog
 
-iptables -t nat -A DOCKER -p udp --dport 8125 -j DNAT --to-destination 34.197.24.237:8125
+sudo iptables -t nat -A DOCKER -p udp --dport 8125 -j DNAT --to-destination 34.197.24.237:8125
 
 CMD python send_to_datadog.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:2-alpine3.7
+
+RUN pip install pipenv
+RUN pipenv install datadog
+
+CMD python send_to_datadog.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:2-alpine3.7
+FROM ubuntu:xenial
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN pip install datadog
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM python:2-alpine3.7
 
-RUN pip install pipenv
-RUN pipenv install datadog
-
-RUN pipenv shell
+RUN pip install datadog
 
 CMD python send_to_datadog.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,3 +3,5 @@ FROM python:2-alpine3.7
 RUN pip install datadog
 
 CMD python send_to_datadog.py
+
+RUN netstat | grep "8125"

--- a/send_to_datadog.py
+++ b/send_to_datadog.py
@@ -7,4 +7,4 @@ options = {'statsd_host': 'localhost',
 
 initialize(**options)
 
-statsd.set('.data.median.firstView.TTFB', '429')
+statsd.set('data.median.firstView.TTFB', '429')

--- a/send_to_datadog.py
+++ b/send_to_datadog.py
@@ -1,0 +1,10 @@
+from datadog import initialize, api
+from datadog import statsd
+
+
+options = {'statsd_host': 'localhost',
+           'statsd_port': '8125'}
+
+initialize(**options)
+
+statsd.set('.data.median.firstView.TTFB', '429')

--- a/send_to_datadog.py
+++ b/send_to_datadog.py
@@ -7,4 +7,4 @@ options = {'statsd_host': 'localhost',
 
 initialize(**options)
 
-statsd.set('data.median.firstView.TTFB', '429')
+statsd.set('wpt.median.firstView.TTFB', '429')


### PR DESCRIPTION
@davehunt @mozilla/firefox-test-engineering r?  please?

The attached screenshot shows this working, as does: https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/wpt-api.test-statsd-send/32/

This partially fixes Issue 16 - "Send filtered perf metrics over to DataDog via statsd."  I say "partially," because there are still more issues to sort out, not the least of which are:

* stripping out leading "." delimiters.  Per https://docs.datadoghq.com/developers/metrics/#metric-names, "metric names must start with a letter."  e.g. https://github.com/mozilla/wpt-api/blob/92994a07923d493eeaa3aca35c99c73c7eadb4f5/jq-filter.txt
* two-parter:
1) accept and send multiple keys + values ("batch mode," I guess?)
2) and, for those keys, actually pass them in.  They are hard-coded, right now, just to test that sending to DataDog via StatsD is working

<img width="1408" alt="screen shot 2018-05-02 at 12 15 12 pm" src="https://user-images.githubusercontent.com/387249/39545512-407629f0-4e06-11e8-8141-b4c8c654ce6b.png">
