### PR TITLE
Filter, format, and send selected, desired Firefox Accounts perf metrics to DataDog, via Jenkins

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,5 @@
 .git
 .gitignore
+*.pyc
+__pycache__
+.cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
+__pycache__
+.cache
 DS_Store
 *.sw[op]
 *.pyc
-__pycache__
-.cache
 .tox
 *.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ RUN pip3 install datadog
 
 # RUN /usr/src/app/bin/webpagetest test "${PAGE_URL}" -l "us-east-1:Firefox" -r 5 --first --poll --reporter json > fxa-homepage.json
 
-# RUN [ "python", "./send_to_datadog.py" ]
+RUN [ "python", "./send_to_datadog.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ ADD send_to_datadog.py /
 
 RUN pip3 install datadog
 
-RUN sh '/usr/src/app/bin/webpagetest test "${PAGE_URL}" -l "us-east-1:Firefox" -r 5 --first --poll --reporter json > fxa-homepage.json'
+# RUN /usr/src/app/bin/webpagetest test "${PAGE_URL}" -l "us-east-1:Firefox" -r 5 --first --poll --reporter json > fxa-homepage.json
 
-CMD [ "python", "./send_to_datadog.py" ]
+# RUN [ "python", "./send_to_datadog.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,6 @@ ADD send_to_datadog.py /
 
 RUN pip3 install datadog
 
+RUN sh '/usr/src/app/bin/webpagetest test "${PAGE_URL}" -l "us-east-1:Firefox" -r 5 --first --poll --reporter json > fxa-homepage.json'
+
 CMD [ "python", "./send_to_datadog.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3
+FROM python:3.6-alpine
 
-ADD send_to_datadog.py /
+WORKDIR /envcat
 
-RUN pip3 install datadog
+ENTRYPOINT ["envcat"]
 
-# RUN /usr/src/app/bin/webpagetest test "${PAGE_URL}" -l "us-east-1:Firefox" -r 5 --first --poll --reporter json > fxa-homepage.json
+COPY . /app
 
-CMD [ "python", "./send_to_datadog.py" ]
+RUN cd /app && pip3 install datadog

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ RUN pip3 install datadog
 
 # RUN /usr/src/app/bin/webpagetest test "${PAGE_URL}" -l "us-east-1:Firefox" -r 5 --first --poll --reporter json > fxa-homepage.json
 
-RUN [ "python", "./send_to_datadog.py" ]
+CMD [ "python", "./send_to_datadog.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM python:3.6-alpine
 
-WORKDIR /envcat
+WORKDIR /src
 
-ENTRYPOINT ["envcat"]
+COPY send_to_datadog.py /src
 
-COPY . /app
+RUN pip3 install datadog
 
-RUN cd /app && pip3 install datadog
+COPY . /src
+
+CMD python send_to_datadog.py

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,9 +7,6 @@ pipeline {
     WEBPAGETEST_SERVER = "https://${WEB_PAGE_TEST}@wpt-api.stage.mozaws.net/"
     PAGE_URL = "https://latest.dev.lcip.org/?service=sync&entrypoint=firstrun&context=fx_desktop_v3"
   }
-  triggers {
-    cron('H/5 * * * *')
-  }
   options {
     ansiColor('xterm')
     timestamps()
@@ -39,9 +36,6 @@ pipeline {
         }
         success {
           stash includes: 'fxa-homepage.json', name: 'fxa-homepage.json'
-        }
-        failure {
-          archiveArtifacts 'fxa-homepage.json'
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
       agent {
         dockerfile {
          dir 'webpagetest-api'
+         additionalBuildArgs '--no-cache'
         }
       }
       steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,16 +23,10 @@ pipeline {
     }
     stage('test') {
       agent {
-        dockerfile {
-         dir 'webpagetest-api'
-         additionalBuildArgs '--no-cache'
-        }
+        dockerfile {dir 'webpagetest-api'}
       }
       steps {
-        sh '''
-        /usr/src/app/bin/webpagetest test addons.mozilla.org -l "us-east-1:Firefox" -r 5 --first --poll --reporter json > "fxa-homepage.json"
-        python send_to_datadog.py
-        '''
+        sh '/usr/src/app/bin/webpagetest test addons.mozilla.org -l "us-east-1:Firefox" -r 5 --first --poll --reporter json > "fxa-homepage.json"'
       }
       post {
         always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
         docker { image 'colstrom/jq' }
       }
       steps {
-        sh 'jq -f jq-filter.txt < fxa-homepage.json > stats.json'
+        sh 'jq -f jq-filter.txt '[.[]|rtrimstr(".")]' < fxa-homepage.json > stats.json'
       }
       post {
         always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,15 +53,15 @@ pipeline {
         unstash 'fxa-homepage.json'
         sh '''
           python --version
-          echo $(pwd)
-          ls .
-          ls $(pwd)
+          # echo $(pwd)
+          #ls .
+          # ls $(pwd)
           # echo ${WORKSPACE}
           # see https://support.cloudbees.com/hc/en-us/articles/230922508-Pipeline-Files-manipulation
-          ls -la send_to_datadog.py
-          chmod +x send_to_datadog.py
+          # ls -la send_to_datadog.py
+          # chmod +x send_to_datadog.py
           python ./send_to_datadog.py
-          ls -la send_to_datadog.py
+          # ls -la send_to_datadog.py
         '''
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
     }
     stage('Submit stats to datadog') {
       agent {
-        dockerfile { dir 'webpagetest-api' }
+        dockerfile true
       }
       steps {
         unstash 'fxa-homepage.json'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,9 @@ pipeline {
     WEBPAGETEST_SERVER = "https://${WEB_PAGE_TEST}@wpt-api.stage.mozaws.net/"
     PAGE_URL = "https://latest.dev.lcip.org/?service=sync&entrypoint=firstrun&context=fx_desktop_v3"
   }
+  triggers {
+    cron('H/5 * * * *')
+  }
   stages {
     stage('clone') {
        agent any

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,18 +33,5 @@ pipeline {
         }
       }
     }
-    stage('filter') {
-      agent {
-        docker { image 'colstrom/jq' }
-      }
-      steps {
-        sh 'jq -f jq-filter.txt < fxa-homepage.json > stats.json'
-      }
-      post {
-        always {
-          archiveArtifacts 'stats.json'
-        }
-      }
-    }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,7 @@ pipeline {
       }
       steps {
         sh '/usr/src/app/bin/webpagetest test addons.mozilla.org -l "us-east-1:Firefox" -r 5 --first --poll --reporter json > "fxa-homepage.json"'
+        sh 'python ./send_to_data_dog.py'
       }
       post {
         always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,21 +47,14 @@ pipeline {
     }
     stage('Submit stats to datadog') {
       agent {
-        dockerfile true
+        dockerfile {
+          args '--net host'
+        }
       }
       steps {
         unstash 'fxa-homepage.json'
         sh '''
-          python --version
-          # echo $(pwd)
-          #ls .
-          # ls $(pwd)
-          # echo ${WORKSPACE}
-          # see https://support.cloudbees.com/hc/en-us/articles/230922508-Pipeline-Files-manipulation
-          # ls -la send_to_datadog.py
-          # chmod +x send_to_datadog.py
           python ./send_to_datadog.py
-          # ls -la send_to_datadog.py
         '''
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,12 @@ pipeline {
          dir 'webpagetest-api'
          additionalBuildArgs '--no-cache'
         }
+     }
+     steps {
+      sh '''
+      '/usr/src/app/bin/webpagetest test addons.mozilla.org -l "us-east-1:Firefox" -r 5 --first --poll --reporter json > "fxa-homepage.json"'
+      python send_to_datadog.py
+      '''
       }
       post {
         always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
         docker { image 'colstrom/jq' }
       }
       steps {
-        sh 'jq -f jq-filter.txt '[.[]|rtrimstr(".")]' < fxa-homepage.json > stats.json'
+        sh 'jq -f jq-filter.txt < fxa-homepage.json > stats.json'
       }
       post {
         always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,9 +28,6 @@ pipeline {
          additionalBuildArgs '--no-cache'
         }
       }
-      steps {
-        sh '/usr/src/app/bin/webpagetest test "${PAGE_URL}" -l "us-east-1:Firefox" -r 5 --first --poll --reporter json > fxa-homepage.json'
-      }
       post {
         always {
           archiveArtifacts 'fxa-homepage.json'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,12 +27,12 @@ pipeline {
          dir 'webpagetest-api'
          additionalBuildArgs '--no-cache'
         }
-     }
-     steps {
-      sh '''
-      '/usr/src/app/bin/webpagetest test addons.mozilla.org -l "us-east-1:Firefox" -r 5 --first --poll --reporter json > "fxa-homepage.json"'
-      python send_to_datadog.py
-      '''
+      }
+      steps {
+        sh '''
+        /usr/src/app/bin/webpagetest test addons.mozilla.org -l "us-east-1:Firefox" -r 5 --first --poll --reporter json > "fxa-homepage.json"
+        python send_to_datadog.py
+        '''
       }
       post {
         always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
         dockerfile { dir 'webpagetest-api' }
       }
       steps {
-        sh '/usr/src/app/bin/webpagetest test addons.mozilla.org -l "us-east-1:Firefox" -r 5 --first --poll --reporter json > "fxa-homepage.json"'
+        sh '/usr/src/app/bin/webpagetest test "${PAGE_URL}" -l "us-east-1:Firefox" -r 5 --first --poll --reporter json > "fxa-homepage.json"'
         }
       post {
         always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,9 @@ pipeline {
     timestamps()
     timeout(time: 30, unit: 'MINUTES')
   }
+  triggers {
+    cron('H/10 * * * *')
+  }
   stages {
     stage('clone') {
        agent any

--- a/envcat
+++ b/envcat
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-docker run --rm -v $(pwd):/envcat mozmeao/envcat:latest "$@"

--- a/envcat
+++ b/envcat
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run --rm -v $(pwd):/envcat mozmeao/envcat:latest "$@"

--- a/jq-filter.txt
+++ b/jq-filter.txt
@@ -1,6 +1,0 @@
-.data.median.firstView.TTFB,
-.data.median.firstView.render,
-.data.median.firstView.SpeedIndex,
-.data.median.firstView.bytesInDoc,
-.data.median.firstView.visualComplete,
-.data.median.firstView.requestsFull

--- a/send_to_datadog.py
+++ b/send_to_datadog.py
@@ -7,10 +7,22 @@ from datadog import statsd
 options = {'statsd_host': 'localhost',
            'statsd_port': '8125'}
 
-with open ('stats.json') as json_data:
-    statsd_data = json.load(json_data)
-    print(statsd_data)
+with open ('fxa-homepage.json') as json_data:
+    loaded_json = json.load(json_data)
+    # dumped_json = json.dumps(loaded_json)
+    # print(dumped_json)
+    print "data.median.firstView.TTFB {}".format(loaded_json["data"]["median"]["firstView"]["TTFB"])
+    print "data.median.firstView.render {}".format(loaded_json["data"]["median"]["firstView"]["render"])
+    print "data.median.firstView.SpeedIndex {}".format(loaded_json["data"]["median"]["firstView"]["SpeedIndex"])
+    print "data.median.firstView.bytesInDoc {}".format(loaded_json["data"]["median"]["firstView"]["bytesInDoc"])
+    print "data.median.firstView.visualComplete {}".format(loaded_json["data"]["median"]["firstView"]["visualComplete"])
+    print "data.median.firstView.requestsFull {}".format(loaded_json["data"]["median"]["firstView"]["requestsFull"])
+
+print('wpt.median.firstView.TTFB', '{}'.format(loaded_json["data"]["median"]["firstView"]["TTFB"]))
+
 
 initialize(**options)
 
-statsd.gauge(statsd_data)
+statsd.gauge('wpt.median.firstView.TTFB.fakeValue', '42')
+statsd.gauge('wpt.median.firstView.TTFB', '{}'.format(loaded_json["data"]["median"]["firstView"]["TTFB"]))
+statsd.gauge('wpt.median.firstView.TTFB', loaded_json["data"]["median"]["firstView"]["TTFB"])

--- a/send_to_datadog.py
+++ b/send_to_datadog.py
@@ -18,17 +18,9 @@ with open ('fxa-homepage.json') as json_data:
     # print("data.median.firstView.visualComplete {}".format(loaded_json["data"]["median"]["firstView"]["visualComplete"]))
     # print("data.median.firstView.requestsFull {}".format(loaded_json["data"]["median"]["firstView"]["requestsFull"]))
 
-# print('wpt.median.firstView.TTFB', '{}'.format(loaded_json["data"]["median"]["firstView"]["TTFB"]))
-
 
 initialize(**options)
 
-# statsd.gauge('wpt.median.firstView.TTFB.fakeValue', '42', sample_rate=1)
-# statsd.gauge('wpt.median.firstView.TTFB', loaded_json["data"]["median"]["firstView"]["TTFB"], sample_rate=1)
+TTFB = loaded_json["data"]["median"]["firstView"]["TTFB"]
 
-
-print("Call statsd.set")
-statsd.set('wpt.median.firstView.TTFB.statsd.set', '43')
-statsd.set('wpt.median.firstView.TTFB', loaded_json["data"]["median"]["firstView"]["TTFB"])
-
-print("And we're done - end of file")
+statsd.gauge('wpt.median.firstView.TTFB', (TTFB))

--- a/send_to_datadog.py
+++ b/send_to_datadog.py
@@ -1,3 +1,5 @@
+import json
+
 from datadog import initialize, api
 from datadog import statsd
 
@@ -5,6 +7,10 @@ from datadog import statsd
 options = {'statsd_host': 'localhost',
            'statsd_port': '8125'}
 
+with open ('stats.json') as json_data:
+    statsd_data = json.load(json_data)
+    print(statsd_data)
+
 initialize(**options)
 
-statsd.gauge('wpt.median.firstView.TTFB', '429')
+statsd.gauge(statsd_data)

--- a/send_to_datadog.py
+++ b/send_to_datadog.py
@@ -23,8 +23,8 @@ print('wpt.median.firstView.TTFB', '{}'.format(loaded_json["data"]["median"]["fi
 
 initialize(**options)
 
-statsd.gauge('wpt.median.firstView.TTFB.fakeValue', '42')
-statsd.gauge('wpt.median.firstView.TTFB', loaded_json["data"]["median"]["firstView"]["TTFB"])
+statsd.gauge('wpt.median.firstView.TTFB.fakeValue', '42', sample_rate=1)
+statsd.gauge('wpt.median.firstView.TTFB', loaded_json["data"]["median"]["firstView"]["TTFB"], sample_rate=1)
 
 # statsd.set('wpt.median.firstView.TTFB.fakeValue', '42')
 # statsd.set('wpt.median.firstView.TTFB', loaded_json["data"]["median"]["firstView"]["TTFB"])

--- a/send_to_datadog.py
+++ b/send_to_datadog.py
@@ -11,7 +11,7 @@ with open ('fxa-homepage.json') as json_data:
     loaded_json = json.load(json_data)
 
     '''
-    Just leaving the example below in, for my own, local reference
+    Just leaving the example below, in, for my own reference
     print("data.median.firstView.TTFB {}".format(loaded_json["data"]["median"]["firstView"]["TTFB"]))
     '''
 

--- a/send_to_datadog.py
+++ b/send_to_datadog.py
@@ -31,12 +31,4 @@ print("Call statsd.set")
 statsd.set('wpt.median.firstView.TTFB.statsd.set', '43')
 statsd.set('wpt.median.firstView.TTFB', loaded_json["data"]["median"]["firstView"]["TTFB"])
 
-
 print("And we're done - end of file")
-
-# stats.gauge('wpt.median.firstView.TTFB.stats.gauge', '43', sample_rate=1, host=localhost, port=8125)
-
-# statsd.gauge('wpt.median.firstView.TTFB.fakeValue', '42', sample_rate=1)
-
-# statsd.set('wpt.median.firstView.TTFB.fakeValue', '42')
-statsd.set('wpt.median.firstView.TTFB', loaded_json["data"]["median"]["firstView"]["TTFB"])

--- a/send_to_datadog.py
+++ b/send_to_datadog.py
@@ -26,8 +26,9 @@ initialize(**options)
 # statsd.gauge('wpt.median.firstView.TTFB.fakeValue', '42', sample_rate=1)
 # statsd.gauge('wpt.median.firstView.TTFB', loaded_json["data"]["median"]["firstView"]["TTFB"], sample_rate=1)
 
-statsd.gauge('wpt.median.firstView.TTFB.statsd.gauge', '43', sample_rate=1, host=localhost, port=8125)
-stats.gauge('wpt.median.firstView.TTFB.stats.gauge', '43', sample_rate=1, host=localhost, port=8125)
+statsd.gauge('wpt.median.firstView.TTFB.statsd.gauge', '43')
+
+# stats.gauge('wpt.median.firstView.TTFB.stats.gauge', '43', sample_rate=1, host=localhost, port=8125)
 
 # statsd.gauge('wpt.median.firstView.TTFB.fakeValue', '42', sample_rate=1)
 

--- a/send_to_datadog.py
+++ b/send_to_datadog.py
@@ -26,5 +26,5 @@ initialize(**options)
 statsd.gauge('wpt.median.firstView.TTFB.fakeValue', '42')
 statsd.gauge('wpt.median.firstView.TTFB', loaded_json["data"]["median"]["firstView"]["TTFB"])
 
-statsd.set('wpt.median.firstView.TTFB.fakeValue', '42')
-statsd.set('wpt.median.firstView.TTFB', loaded_json["data"]["median"]["firstView"]["TTFB"])
+# statsd.set('wpt.median.firstView.TTFB.fakeValue', '42')
+# statsd.set('wpt.median.firstView.TTFB', loaded_json["data"]["median"]["firstView"]["TTFB"])

--- a/send_to_datadog.py
+++ b/send_to_datadog.py
@@ -23,10 +23,10 @@ print('wpt.median.firstView.TTFB', '{}'.format(loaded_json["data"]["median"]["fi
 
 initialize(**options)
 
-statsd.gauge('wpt.median.firstView.TTFB.fakeValue', '42', sample_rate=1)
-statsd.gauge('wpt.median.firstView.TTFB', loaded_json["data"]["median"]["firstView"]["TTFB"], sample_rate=1)
+# statsd.gauge('wpt.median.firstView.TTFB.fakeValue', '42', sample_rate=1)
+# statsd.gauge('wpt.median.firstView.TTFB', loaded_json["data"]["median"]["firstView"]["TTFB"], sample_rate=1)
 
-dog.gauge('wpt.median.firstView.TTFB.fakeValue', '42', sample_rate=1)
+self.gauge('wpt.median.firstView.TTFB.fakeValue', '42', sample_rate=1)
 
 # statsd.set('wpt.median.firstView.TTFB.fakeValue', '42')
 # statsd.set('wpt.median.firstView.TTFB', loaded_json["data"]["median"]["firstView"]["TTFB"])

--- a/send_to_datadog.py
+++ b/send_to_datadog.py
@@ -9,18 +9,25 @@ options = {'statsd_host': 'localhost',
 
 with open ('fxa-homepage.json') as json_data:
     loaded_json = json.load(json_data)
-    # dumped_json = json.dumps(loaded_json)
-    # print(dumped_json)
-    # print("data.median.firstView.TTFB {}".format(loaded_json["data"]["median"]["firstView"]["TTFB"]))
-    # print("data.median.firstView.render {}".format(loaded_json["data"]["median"]["firstView"]["render"]))
-    # print("data.median.firstView.SpeedIndex {}".format(loaded_json["data"]["median"]["firstView"]["SpeedIndex"]))
-    # print("data.median.firstView.bytesInDoc {}".format(loaded_json["data"]["median"]["firstView"]["bytesInDoc"]))
-    # print("data.median.firstView.visualComplete {}".format(loaded_json["data"]["median"]["firstView"]["visualComplete"]))
-    # print("data.median.firstView.requestsFull {}".format(loaded_json["data"]["median"]["firstView"]["requestsFull"]))
+
+    '''
+    Just leaving the example below in, for my own, local reference
+    print("data.median.firstView.TTFB {}".format(loaded_json["data"]["median"]["firstView"]["TTFB"]))
+    '''
 
 
 initialize(**options)
 
 TTFB = loaded_json["data"]["median"]["firstView"]["TTFB"]
+render = loaded_json["data"]["median"]["firstView"]["render"]
+SpeedIndex = loaded_json["data"]["median"]["firstView"]["SpeedIndex"]
+bytesInDoc = loaded_json["data"]["median"]["firstView"]["bytesInDoc"]
+visualComplete = loaded_json["data"]["median"]["firstView"]["visualComplete"]
+requestsFull = loaded_json["data"]["median"]["firstView"]["requestsFull"]
 
 statsd.gauge('wpt.median.firstView.TTFB', (TTFB))
+statsd.gauge('wpt.median.firstView.render', (render))
+statsd.gauge('wpt.median.firstView.SpeedIndex', (SpeedIndex))
+statsd.gauge('wpt.median.firstView.bytesInDoc', (bytesInDoc))
+statsd.gauge('wpt.median.firstView.visualComplete', (visualComplete))
+statsd.gauge('wpt.median.firstView.requestsFull', (requestsFull))

--- a/send_to_datadog.py
+++ b/send_to_datadog.py
@@ -29,6 +29,8 @@ initialize(**options)
 
 print("Call statsd.set")
 statsd.set('wpt.median.firstView.TTFB.statsd.set', '43')
+statsd.set('wpt.median.firstView.TTFB', loaded_json["data"]["median"]["firstView"]["TTFB"])
+
 
 print("And we're done - end of file")
 
@@ -37,4 +39,4 @@ print("And we're done - end of file")
 # statsd.gauge('wpt.median.firstView.TTFB.fakeValue', '42', sample_rate=1)
 
 # statsd.set('wpt.median.firstView.TTFB.fakeValue', '42')
-# statsd.set('wpt.median.firstView.TTFB', loaded_json["data"]["median"]["firstView"]["TTFB"])
+statsd.set('wpt.median.firstView.TTFB', loaded_json["data"]["median"]["firstView"]["TTFB"])

--- a/send_to_datadog.py
+++ b/send_to_datadog.py
@@ -24,5 +24,4 @@ print('wpt.median.firstView.TTFB', '{}'.format(loaded_json["data"]["median"]["fi
 initialize(**options)
 
 statsd.gauge('wpt.median.firstView.TTFB.fakeValue', '42')
-statsd.gauge('wpt.median.firstView.TTFB', '{}'.format(loaded_json["data"]["median"]["firstView"]["TTFB"]))
 statsd.gauge('wpt.median.firstView.TTFB', loaded_json["data"]["median"]["firstView"]["TTFB"])

--- a/send_to_datadog.py
+++ b/send_to_datadog.py
@@ -11,14 +11,14 @@ with open ('fxa-homepage.json') as json_data:
     loaded_json = json.load(json_data)
     # dumped_json = json.dumps(loaded_json)
     # print(dumped_json)
-    print "data.median.firstView.TTFB {}".format(loaded_json["data"]["median"]["firstView"]["TTFB"])
-    print "data.median.firstView.render {}".format(loaded_json["data"]["median"]["firstView"]["render"])
-    print "data.median.firstView.SpeedIndex {}".format(loaded_json["data"]["median"]["firstView"]["SpeedIndex"])
-    print "data.median.firstView.bytesInDoc {}".format(loaded_json["data"]["median"]["firstView"]["bytesInDoc"])
-    print "data.median.firstView.visualComplete {}".format(loaded_json["data"]["median"]["firstView"]["visualComplete"])
-    print "data.median.firstView.requestsFull {}".format(loaded_json["data"]["median"]["firstView"]["requestsFull"])
+    print("data.median.firstView.TTFB {}".format(loaded_json["data"]["median"]["firstView"]["TTFB"]))
+    print("data.median.firstView.render {}".format(loaded_json["data"]["median"]["firstView"]["render"]))
+    print("data.median.firstView.SpeedIndex {}".format(loaded_json["data"]["median"]["firstView"]["SpeedIndex"]))
+    print("data.median.firstView.bytesInDoc {}".format(loaded_json["data"]["median"]["firstView"]["bytesInDoc"]))
+    print("data.median.firstView.visualComplete {}".format(loaded_json["data"]["median"]["firstView"]["visualComplete"]))
+    print("data.median.firstView.requestsFull {}".format(loaded_json["data"]["median"]["firstView"]["requestsFull"]))
 
-print('wpt.median.firstView.TTFB', '{}'.format(loaded_json["data"]["median"]["firstView"]["TTFB"]))
+# print('wpt.median.firstView.TTFB', '{}'.format(loaded_json["data"]["median"]["firstView"]["TTFB"]))
 
 
 initialize(**options)

--- a/send_to_datadog.py
+++ b/send_to_datadog.py
@@ -25,3 +25,6 @@ initialize(**options)
 
 statsd.gauge('wpt.median.firstView.TTFB.fakeValue', '42')
 statsd.gauge('wpt.median.firstView.TTFB', loaded_json["data"]["median"]["firstView"]["TTFB"])
+
+statsd.set('wpt.median.firstView.TTFB.fakeValue', '42')
+statsd.set('wpt.median.firstView.TTFB', loaded_json["data"]["median"]["firstView"]["TTFB"])

--- a/send_to_datadog.py
+++ b/send_to_datadog.py
@@ -28,6 +28,8 @@ initialize(**options)
 
 statsd.gauge('wpt.median.firstView.TTFB.statsd.gauge', '43')
 
+print("eof")
+
 # stats.gauge('wpt.median.firstView.TTFB.stats.gauge', '43', sample_rate=1, host=localhost, port=8125)
 
 # statsd.gauge('wpt.median.firstView.TTFB.fakeValue', '42', sample_rate=1)

--- a/send_to_datadog.py
+++ b/send_to_datadog.py
@@ -26,7 +26,7 @@ initialize(**options)
 # statsd.gauge('wpt.median.firstView.TTFB.fakeValue', '42', sample_rate=1)
 # statsd.gauge('wpt.median.firstView.TTFB', loaded_json["data"]["median"]["firstView"]["TTFB"], sample_rate=1)
 
-statsd.gauge('wpt.median.firstView.TTFB.statsd.gauge', '43')
+statsd.set('wpt.median.firstView.TTFB.statsd.set', '43')
 
 print("eof")
 

--- a/send_to_datadog.py
+++ b/send_to_datadog.py
@@ -26,5 +26,7 @@ initialize(**options)
 statsd.gauge('wpt.median.firstView.TTFB.fakeValue', '42', sample_rate=1)
 statsd.gauge('wpt.median.firstView.TTFB', loaded_json["data"]["median"]["firstView"]["TTFB"], sample_rate=1)
 
+dog.gauge('wpt.median.firstView.TTFB.fakeValue', '42', sample_rate=1)
+
 # statsd.set('wpt.median.firstView.TTFB.fakeValue', '42')
 # statsd.set('wpt.median.firstView.TTFB', loaded_json["data"]["median"]["firstView"]["TTFB"])

--- a/send_to_datadog.py
+++ b/send_to_datadog.py
@@ -11,12 +11,12 @@ with open ('fxa-homepage.json') as json_data:
     loaded_json = json.load(json_data)
     # dumped_json = json.dumps(loaded_json)
     # print(dumped_json)
-    print("data.median.firstView.TTFB {}".format(loaded_json["data"]["median"]["firstView"]["TTFB"]))
-    print("data.median.firstView.render {}".format(loaded_json["data"]["median"]["firstView"]["render"]))
-    print("data.median.firstView.SpeedIndex {}".format(loaded_json["data"]["median"]["firstView"]["SpeedIndex"]))
-    print("data.median.firstView.bytesInDoc {}".format(loaded_json["data"]["median"]["firstView"]["bytesInDoc"]))
-    print("data.median.firstView.visualComplete {}".format(loaded_json["data"]["median"]["firstView"]["visualComplete"]))
-    print("data.median.firstView.requestsFull {}".format(loaded_json["data"]["median"]["firstView"]["requestsFull"]))
+    # print("data.median.firstView.TTFB {}".format(loaded_json["data"]["median"]["firstView"]["TTFB"]))
+    # print("data.median.firstView.render {}".format(loaded_json["data"]["median"]["firstView"]["render"]))
+    # print("data.median.firstView.SpeedIndex {}".format(loaded_json["data"]["median"]["firstView"]["SpeedIndex"]))
+    # print("data.median.firstView.bytesInDoc {}".format(loaded_json["data"]["median"]["firstView"]["bytesInDoc"]))
+    # print("data.median.firstView.visualComplete {}".format(loaded_json["data"]["median"]["firstView"]["visualComplete"]))
+    # print("data.median.firstView.requestsFull {}".format(loaded_json["data"]["median"]["firstView"]["requestsFull"]))
 
 # print('wpt.median.firstView.TTFB', '{}'.format(loaded_json["data"]["median"]["firstView"]["TTFB"]))
 

--- a/send_to_datadog.py
+++ b/send_to_datadog.py
@@ -26,9 +26,11 @@ initialize(**options)
 # statsd.gauge('wpt.median.firstView.TTFB.fakeValue', '42', sample_rate=1)
 # statsd.gauge('wpt.median.firstView.TTFB', loaded_json["data"]["median"]["firstView"]["TTFB"], sample_rate=1)
 
+
+print("Call statsd.set")
 statsd.set('wpt.median.firstView.TTFB.statsd.set', '43')
 
-print("eof")
+print("And we're done - end of file")
 
 # stats.gauge('wpt.median.firstView.TTFB.stats.gauge', '43', sample_rate=1, host=localhost, port=8125)
 

--- a/send_to_datadog.py
+++ b/send_to_datadog.py
@@ -26,7 +26,10 @@ initialize(**options)
 # statsd.gauge('wpt.median.firstView.TTFB.fakeValue', '42', sample_rate=1)
 # statsd.gauge('wpt.median.firstView.TTFB', loaded_json["data"]["median"]["firstView"]["TTFB"], sample_rate=1)
 
-self.gauge('wpt.median.firstView.TTFB.fakeValue', '42', sample_rate=1)
+statsd.gauge('wpt.median.firstView.TTFB.statsd.gauge', '43', sample_rate=1, host=localhost, port=8125)
+stats.gauge('wpt.median.firstView.TTFB.stats.gauge', '43', sample_rate=1, host=localhost, port=8125)
+
+# statsd.gauge('wpt.median.firstView.TTFB.fakeValue', '42', sample_rate=1)
 
 # statsd.set('wpt.median.firstView.TTFB.fakeValue', '42')
 # statsd.set('wpt.median.firstView.TTFB', loaded_json["data"]["median"]["firstView"]["TTFB"])


### PR DESCRIPTION
@mozilla/firefox-test-engineering r?

Fixes https://github.com/mozilla/wpt-api/issues/16 and obviates/fixes https://github.com/mozilla/wpt-api/issues/22 (and, likely, a bunch more!)

While there is still quite a bit of cleanup and extending to do, I'm very, very happy that this is pretty lightweight, readable, etc.

**_The eagle has landed!_**

/cc @philbooth @muffinresearch @@onkeltom @digitarald @kannanvijayan @stuartphilp oh, and @jbuck, so he knows why I'm pestering him about the wpt-api instance, of late :-)

Edit: Glorious screenshot of plotted metric data in DataDog, gratuitously included for satisfaction.

<img width="1792" alt="screen shot 2018-05-11 at 5 50 43 pm" src="https://user-images.githubusercontent.com/387249/39951999-70f9fcf6-5544-11e8-9da8-ef11e46117e5.png">
