### PR TITLE
Use us-east-1-linux location, to use timeToNonBlankPaint (firstPaint)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
         dockerfile { dir 'webpagetest-api' }
       }
       steps {
-        sh '/usr/src/app/bin/webpagetest test "${PAGE_URL}" -l "us-east-1:Firefox" -r 5 --first --poll --reporter json > "fxa-homepage.json"'
+        sh '/usr/src/app/bin/webpagetest test "${PAGE_URL}" -l "us-east-1-linux:Firefox" -r 5 --first --poll --reporter json > "fxa-homepage.json"'
         }
       post {
         always {

--- a/README.md
+++ b/README.md
@@ -11,13 +11,14 @@ The currently implemented workflow, on the ```master``` branch, supports:
 
 * Passing in a custom ```PAGE_URL``` to override the hardcoded default[0]:
 * Running tests against the URL with the following hardcoded parameters:
-  - in the ```us-east-1``` EC2 region
+  - in the ```us-east-1-linux``` EC2 region
   - 5 times
-  - recent Firefox release
+  - recent Firefox release build, on Linux
   - using ```--first``` (no caching)
 * Post-WebPageTest run, we export and archive its output (via Jenkins) as ```fxa-homepage.json```[1]
 * Next, we filter for and extract[2]:
   - Time To First Byte (TTFB)
+  - Time To Non-Blank Paint, aka ```firstPaint``` (firstPaint)
   - Start render (render)
   - Speed Index (SpeedIndex)
   - Total Bytes Transferred (bytesInDoc)

--- a/send_to_datadog.py
+++ b/send_to_datadog.py
@@ -19,6 +19,7 @@ with open('fxa-homepage.json') as json_data:
 initialize(**options)
 
 TTFB = loaded_json["data"]["median"]["firstView"]["TTFB"]
+timeToNonBlankPaint = loaded_json["data"]["median"]["firstView"]["firstPaint"]
 render = loaded_json["data"]["median"]["firstView"]["render"]
 SpeedIndex = loaded_json["data"]["median"]["firstView"]["SpeedIndex"]
 bytesInDoc = loaded_json["data"]["median"]["firstView"]["bytesInDoc"]
@@ -26,6 +27,7 @@ visualComplete = loaded_json["data"]["median"]["firstView"]["visualComplete"]
 requestsFull = loaded_json["data"]["median"]["firstView"]["requestsFull"]
 
 statsd.gauge('wpt.median.firstView.TTFB', (TTFB))
+statsd.gauge('wpt.median.firstView.timeToNonBlankPaint', (timeToNonBlankPaint))
 statsd.gauge('wpt.median.firstView.render', (render))
 statsd.gauge('wpt.median.firstView.SpeedIndex', (SpeedIndex))
 statsd.gauge('wpt.median.firstView.bytesInDoc', (bytesInDoc))


### PR DESCRIPTION
r?  @mozilla/firefox-test-engineering 

Passing ad-hoc job here: https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/wpt-api.fxa-perf.adhoc/5126/

Also, screenshot of this "new" metric working grandly, in DataDog 🎉 

/cc @philbooth (and a huge thanks, again, to @jbuck <3)

<img width="2032" alt="screen shot 2018-07-25 at 3 42 01 pm" src="https://user-images.githubusercontent.com/387249/43231600-ea205158-9021-11e8-8b35-c86c260a796a.png">
