### PR TITLE
Add Time to DOMContentFlushed metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The currently implemented setup, on the ```alexa-topsites``` branch, supports th
     - Time To First Byte (TTFB)
     - Start render (render)
     - Time To First Non-Blank Paint, aka ```firstPaint``` (firstPaint)
-    - Time to DOMContentFlushed (DOMContentFlushed)
+    - Time to DOMContentFlushed (domContentFlushed)
     - Speed Index (SpeedIndex)
     - Total # of Bytes Transferred (bytesInDoc)
     - Time to Visually Complete (visualComplete)

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ The currently implemented setup, on the ```alexa-topsites``` branch, supports th
 3. Post-WebPageTest run, we export and archive its output (via Jenkins) as ```alexa-topsites.json```[0]
 4. Next, we filter for and extract the following performance-timing metrics[1]:
     - Time To First Byte (TTFB)
-    - Time To First Non-Blank Paint, aka ```firstPaint``` (firstPaint)
     - Start render (render)
+    - Time To First Non-Blank Paint, aka ```firstPaint``` (firstPaint)
+    - Time to DOMContentFlushed (DOMContentFlushed)
     - Speed Index (SpeedIndex)
     - Total # of Bytes Transferred (bytesInDoc)
     - Time to Visually Complete (visualComplete)

--- a/send_to_datadog.py
+++ b/send_to_datadog.py
@@ -22,7 +22,7 @@ test_names = ['google.fx.release', 'google.fx.nightly', 'google.chrome.release',
               'youtube.fx.release', 'youtube.fx.nightly',
               'youtube.chrome.release', 'facebook.fx.release',
               'facebook.fx.nightly', 'facebook.chrome.release']
-metrics = ['TTFB', 'render', 'firstPaint', 'SpeedIndex', 'bytesInDoc',
+metrics = ['TTFB', 'render', 'firstPaint', 'DOMContentFlushed', 'SpeedIndex', 'bytesInDoc',
            'visualComplete', 'requestsFull']
 
 for test_name in test_names:

--- a/send_to_datadog.py
+++ b/send_to_datadog.py
@@ -22,7 +22,7 @@ test_names = ['google.fx.release', 'google.fx.nightly', 'google.chrome.release',
               'youtube.fx.release', 'youtube.fx.nightly',
               'youtube.chrome.release', 'facebook.fx.release',
               'facebook.fx.nightly', 'facebook.chrome.release']
-metrics = ['TTFB', 'render', 'firstPaint', 'DOMContentFlushed', 'SpeedIndex', 'bytesInDoc',
+metrics = ['TTFB', 'render', 'firstPaint', 'domContentFlushed', 'SpeedIndex', 'bytesInDoc',
            'visualComplete', 'requestsFull']
 
 for test_name in test_names:


### PR DESCRIPTION
This makes use of a relatively new metric Time to DOMContentFlushed, aka ```DOMContentFlushed```, from https://bugzilla.mozilla.org/show_bug.cgi?id=1457325.

It depends on https://github.com/mozilla-services/webpagetest-settings/pull/5 being in and the internal webpagetest instance being updated, before using.

@mozilla/firefox-test-engineering @philbooth @jbuck r?