### PR TITLE
Add --keepua to preserve all original browsers' user-agents

### DIFF
--- a/commands.txt
+++ b/commands.txt
@@ -1,40 +1,40 @@
-test google.com --location us-east-1-linux:Firefox -r 5 --first --poll --reporter json
-test google.com --location us-east-1-linux:Firefox Nightly -r 5 --first --poll --reporter json
-test google.com --location us-east-1-linux:Chrome -r 5 --first --poll --reporter json
-test google.com --location us-east-1-linux:Chrome Canary -r 5 --first --poll --reporter json
-test youtube.com --location us-east-1-linux:Firefox -r 5 --first --poll --reporter json
-test youtube.com --location us-east-1-linux:Firefox Nightly -r 5 --first --poll --reporter json
-test youtube.com --location us-east-1-linux:Chrome -r 5 --first --poll --reporter json
-test youtube.com --location us-east-1-linux:Chrome Canary -r 5 --first --poll --reporter json
-test facebook.com --location us-east-1-linux:Firefox -r 5 --first --poll --reporter json
-test facebook.com --location us-east-1-linux:Firefox Nightly -r 5 --first --poll --reporter json
-test facebook.com --location us-east-1-linux:Chrome -r 5 --first --poll --reporter json
-test facebook.com --location us-east-1-linux:Chrome Canary -r 5 --first --poll --reporter json
-test baidu.com --location us-east-1-linux:Firefox -r 5 --first --poll --reporter json
-test baidu.com --location us-east-1-linux:Firefox Nightly -r 5 --first --poll --reporter json
-test baidu.com --location us-east-1-linux:Chrome -r 5 --first --poll --reporter json
-test baidu.com --location us-east-1-linux:Chrome Canary -r 5 --first --poll --reporter json
-test wikipedia.org --location us-east-1-linux:Firefox -r 5 --first --poll --reporter json
-test wikipedia.org --location us-east-1-linux:Firefox Nightly -r 5 --first --poll --reporter json
-test wikipedia.org --location us-east-1-linux:Chrome -r 5 --first --poll --reporter json
-test wikipedia.org --location us-east-1-linux:Chrome Canary -r 5 --first --poll --reporter json
-test yahoo.com --location us-east-1-linux:Firefox -r 5 --first --poll --reporter json
-test yahoo.com --location us-east-1-linux:Firefox Nightly -r 5 --first --poll --reporter json
-test yahoo.com --location us-east-1-linux:Chrome -r 5 --first --poll --reporter json
-test yahoo.com --location us-east-1-linux:Chrome Canary -r 5 --first --poll --reporter json
-test qq.com --location us-east-1-linux:Firefox -r 5 --first --poll --reporter json
-test qq.com --location us-east-1-linux:Firefox Nightly -r 5 --first --poll --reporter json
-test qq.com --location us-east-1-linux:Chrome -r 5 --first --poll --reporter json
-test qq.com --location us-east-1-linux:Chrome Canary -r 5 --first --poll --reporter json
-test taobao.com --location us-east-1-linux:Firefox -r 5 --first --poll --reporter json
-test taobao.com --location us-east-1-linux:Firefox Nightly -r 5 --first --poll --reporter json
-test taobao.com --location us-east-1-linux:Chrome -r 5 --first --poll --reporter json
-test taobao.com --location us-east-1-linux:Chrome Canary -r 5 --first --poll --reporter json
-test tmall.com --location us-east-1-linux:Firefox -r 5 --first --poll --reporter json
-test tmall.com --location us-east-1-linux:Firefox Nightly -r 5 --first --poll --reporter json
-test tmall.com --location us-east-1-linux:Chrome -r 5 --first --poll --reporter json
-test tmall.com --location us-east-1-linux:Chrome Canary -r 5 --first --poll --reporter json
-test twitter.com --location us-east-1-linux:Firefox -r 5 --first --poll --reporter json
-test twitter.com --location us-east-1-linux:Firefox Nightly -r 5 --first --poll --reporter json
-test twitter.com --location us-east-1-linux:Chrome -r 5 --first --poll --reporter json
-test twitter.com --location us-east-1-linux:Chrome Canary -r 5 --first --poll --reporter json
+test google.com --location us-east-1-linux:Firefox --keepua -r 5 --first --poll --reporter json
+test google.com --location us-east-1-linux:Firefox Nightly --keepua -r 5 --first --poll --reporter json
+test google.com --location us-east-1-linux:Chrome --keepua -r 5 --first --poll --reporter json
+test google.com --location us-east-1-linux:Chrome Canary --keepua -r 5 --first --poll --reporter json
+test youtube.com --location us-east-1-linux:Firefox --keepua -r 5 --first --poll --reporter json
+test youtube.com --location us-east-1-linux:Firefox Nightly --keepua -r 5 --first --poll --reporter json
+test youtube.com --location us-east-1-linux:Chrome --keepua -r 5 --first --poll --reporter json
+test youtube.com --location us-east-1-linux:Chrome Canary --keepua -r 5 --first --poll --reporter json
+test facebook.com --location us-east-1-linux:Firefox --keepua -r 5 --first --poll --reporter json
+test facebook.com --location us-east-1-linux:Firefox Nightly --keepua -r 5 --first --poll --reporter json
+test facebook.com --location us-east-1-linux:Chrome --keepua -r 5 --first --poll --reporter json
+test facebook.com --location us-east-1-linux:Chrome Canary --keepua -r 5 --first --poll --reporter json
+test baidu.com --location us-east-1-linux:Firefox --keepua -r 5 --first --poll --reporter json
+test baidu.com --location us-east-1-linux:Firefox Nightly --keepua -r 5 --first --poll --reporter json
+test baidu.com --location us-east-1-linux:Chrome --keepua -r 5 --first --poll --reporter json
+test baidu.com --location us-east-1-linux:Chrome Canary --keepua -r 5 --first --poll --reporter json
+test wikipedia.org --location us-east-1-linux:Firefox --keepua -r 5 --first --poll --reporter json
+test wikipedia.org --location us-east-1-linux:Firefox Nightly --keepua -r 5 --first --poll --reporter json
+test wikipedia.org --location us-east-1-linux:Chrome --keepua -r 5 --first --poll --reporter json
+test wikipedia.org --location us-east-1-linux:Chrome Canary --keepua -r 5 --first --poll --reporter json
+test yahoo.com --location us-east-1-linux:Firefox --keepua -r 5 --first --poll --reporter json
+test yahoo.com --location us-east-1-linux:Firefox --keepua Nightly -r 5 --first --poll --reporter json
+test yahoo.com --location us-east-1-linux:Chrome --keepua -r 5 --first --poll --reporter json
+test yahoo.com --location us-east-1-linux:Chrome Canary --keepua -r 5 --first --poll --reporter json
+test qq.com --location us-east-1-linux:Firefox --keepua -r 5 --first --poll --reporter json
+test qq.com --location us-east-1-linux:Firefox Nightly --keepua -r 5 --first --poll --reporter json
+test qq.com --location us-east-1-linux:Chrome --keepua -r 5 --first --poll --reporter json
+test qq.com --location us-east-1-linux:Chrome Canary --keepua -r 5 --first --poll --reporter json
+test taobao.com --location us-east-1-linux:Firefox --keepua -r 5 --first --poll --reporter json
+test taobao.com --location us-east-1-linux:Firefox Nightly --keepua -r 5 --first --poll --reporter json
+test taobao.com --location us-east-1-linux:Chrome --keepua -r 5 --first --poll --reporter json
+test taobao.com --location us-east-1-linux:Chrome Canary --keepua -r 5 --first --poll --reporter json
+test tmall.com --location us-east-1-linux:Firefox --keepua -r 5 --first --poll --reporter json
+test tmall.com --location us-east-1-linux:Firefox Nightly --keepua -r 5 --first --poll --reporter json
+test tmall.com --location us-east-1-linux:Chrome --keepua -r 5 --first --poll --reporter json
+test tmall.com --location us-east-1-linux:Chrome Canary --keepua -r 5 --first --poll --reporter json
+test twitter.com --location us-east-1-linux:Firefox --keepua -r 5 --first --poll --reporter json
+test twitter.com --location us-east-1-linux:Firefox Nightly --keepua -r 5 --first --poll --reporter json
+test twitter.com --location us-east-1-linux:Chrome --keepua -r 5 --first --poll --reporter json
+test twitter.com --location us-east-1-linux:Chrome Canary --keepua -r 5 --first --poll --reporter json


### PR DESCRIPTION
Fixes https://github.com/mozilla/wpt-api/issues/101; but I'd like a general consensus or at least awareness from the team at large, that this is OK/happening, first.

EDIT: Update - nobody yet has objected, and I have a couple approvals already (Stuart, folks in #perfteam).