### PR TITLE
Revert "Add 20 more Alexa Topsites; we are now at 30"

### DIFF
--- a/commands.txt
+++ b/commands.txt
@@ -18,14 +18,14 @@ test https://www.wikipedia.org --location us-east-1-linux:Firefox --bodies --kee
 test https://www.wikipedia.org --location us-east-1-linux:Firefox Nightly --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
 test https://www.wikipedia.org --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
 test https://www.wikipedia.org --location us-east-1-linux:Chrome Canary --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.qq.com --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.qq.com --location us-east-1-linux:Firefox Nightly --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.qq.com --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.qq.com --location us-east-1-linux:Chrome Canary --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
 test https://www.yahoo.com --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
 test https://www.yahoo.com --location us-east-1-linux:Firefox Nightly --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
 test https://www.yahoo.com --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
 test https://www.yahoo.com --location us-east-1-linux:Chrome Canary --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
+test https://www.qq.com --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
+test https://www.qq.com --location us-east-1-linux:Firefox Nightly --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
+test https://www.qq.com --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
+test https://www.qq.com --location us-east-1-linux:Chrome Canary --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
 test https://www.taobao.com --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
 test https://www.taobao.com --location us-east-1-linux:Firefox Nightly --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
 test https://www.taobao.com --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
@@ -34,87 +34,7 @@ test https://www.tmall.com --location us-east-1-linux:Firefox --bodies --keepua 
 test https://www.tmall.com --location us-east-1-linux:Firefox Nightly --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
 test https://www.tmall.com --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
 test https://www.tmall.com --location us-east-1-linux:Chrome Canary --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.amazon.com --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.amazon.com --location us-east-1-linux:Firefox Nightly --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.amazon.com --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.amazon.com --location us-east-1-linux:Chrome Canary --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
 test https://www.twitter.com --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
 test https://www.twitter.com --location us-east-1-linux:Firefox Nightly --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
 test https://www.twitter.com --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
 test https://www.twitter.com --location us-east-1-linux:Chrome Canary --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.sohu.com --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.sohu.com --location us-east-1-linux:Firefox Nightly --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.sohu.com --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.sohu.com --location us-east-1-linux:Chrome Canary --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.instagram.com --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.instagram.com --location us-east-1-linux:Firefox Nightly --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.instagram.com --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.instagram.com --location us-east-1-linux:Chrome Canary --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.live.com --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.live.com --location us-east-1-linux:Firefox Nightly --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.live.com --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.live.com --location us-east-1-linux:Chrome Canary --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.jd.com --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.jd.com --location us-east-1-linux:Firefox Nightly --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.jd.com --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.jd.com --location us-east-1-linux:Chrome Canary --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.weibo.com --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.weibo.com --location us-east-1-linux:Firefox Nightly --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.weibo.com --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.weibo.com --location us-east-1-linux:Chrome Canary --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.reddit.com --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.reddit.com --location us-east-1-linux:Firefox Nightly --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.reddit.com --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.reddit.com --location us-east-1-linux:Chrome Canary --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.sina.com.cn --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.sina.com.cn --location us-east-1-linux:Firefox Nightly --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.sina.com.cn --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.sina.com.cn --location us-east-1-linux:Chrome Canary --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.vk.com --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.vk.com --location us-east-1-linux:Firefox Nightly --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.vk.com --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.vk.com --location us-east-1-linux:Chrome Canary --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.360.cn --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.360.cn --location us-east-1-linux:Firefox Nightly --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.360.cn --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.360.cn --location us-east-1-linux:Chrome Canary --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.yandex.ru --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.yandex.ru --location us-east-1-linux:Firefox Nightly --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.yandex.ru --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.yandex.ru --location us-east-1-linux:Chrome Canary --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.blogspot.com --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.blogspot.com --location us-east-1-linux:Firefox Nightly --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.blogspot.com --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.blogspot.com --location us-east-1-linux:Chrome Canary --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.netflix.com --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.netflix.com --location us-east-1-linux:Firefox Nightly --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.netflix.com --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.netflix.com --location us-east-1-linux:Chrome Canary --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.linkedin.com --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.linkedin.com --location us-east-1-linux:Firefox Nightly --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.linkedin.com --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.linkedin.com --location us-east-1-linux:Chrome Canary --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.linkedin.com --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.linkedin.com --location us-east-1-linux:Firefox Nightly --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.linkedin.com --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.linkedin.com --location us-east-1-linux:Chrome Canary --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.twitch.tv --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.twitch.tv --location us-east-1-linux:Firefox Nightly --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.twitch.tv --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.twitch.tv --location us-east-1-linux:Chrome Canary --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.csdn.net --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.csdn.net --location us-east-1-linux:Firefox Nightly --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.csdn.net --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.csdn.net --location us-east-1-linux:Chrome Canary --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.mail.ru --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.mail.ru --location us-east-1-linux:Firefox Nightly --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.mail.ru --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.mail.ru --location us-east-1-linux:Chrome Canary --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.alipay.com --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.alipay.com --location us-east-1-linux:Firefox Nightly --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.alipay.com --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.alipay.com --location us-east-1-linux:Chrome Canary --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.office.com --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.office.com --location us-east-1-linux:Firefox Nightly --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.office.com --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites
-test https://www.office.com --location us-east-1-linux:Chrome Canary --bodies --keepua -r 3 --first --poll --reporter json --label alexa-topsites


### PR DESCRIPTION
Reverts mozilla/wpt-api#111

This broke, with this error, which I can't figure out - wanted to get a few good runs in before we can look at this issue more closely/together.

```
04:23:50 [wpt-api.perf.alexa-topsites] Running shell script
04:23:50 + /usr/src/app/bin/webpagetest batch commands.txt
Post stage
05:49:29 /usr/src/app/bin/webpagetest:228
05:49:29         results.length ? JSON.stringify(results, null, 2) : '',
05:49:29                               ^
05:49:29 
05:49:29 RangeError: Invalid string length
05:49:29     at join (native)
05:49:29     at Object.stringify (native)
05:49:29     at checkDone (/usr/src/app/bin/webpagetest:228:31)
05:49:29     at checkError (/usr/src/app/bin/webpagetest:236:5)
05:49:29     at aggregate (/usr/src/app/bin/webpagetest:241:5)
05:49:29     at resultsCallback (/usr/src/app/lib/webpagetest.js:352:7)
05:49:29     at WebPageTest.poll (/usr/src/app/lib/webpagetest.js:365:7)
05:49:29     at callbackYield (/usr/src/app/lib/webpagetest.js:159:14)
05:49:29     at WebPageTest.apiCallback (/usr/src/app/lib/webpagetest.js:228:7)
05:49:29     at unzip (/usr/src/app/lib/webpagetest.js:136:15)
[Pipeline] step
05:49:29 Archiving artifacts
[Pipeline] }
05:49:30 $ docker stop --time=1 92823c927a2abf188968fc746089d1373574d67ee2f26269776af6c9f8ed9151
05:49:31 $ docker rm -f 92823c927a2abf188968fc746089d1373574d67ee2f26269776af6c9f8ed9151
```