### PR TITLE
Bump Jenkins job timeouts to 30 min

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
   options {
     ansiColor('xterm')
     timestamps()
-    timeout(time: 15, unit: 'MINUTES')
+    timeout(time: 30, unit: 'MINUTES')
   }
   stages {
     stage('clone') {


### PR DESCRIPTION
@davehunt @jbuck - I have no solid proof that this will help ameliorate our job + test failures, but it might be worth a shot?

Symptoms leading to this hacky-ish PR are:

1. Tests/site-URL jobs running for longer than 15 minutes, and timing out (Jenkins timeout, the default of which here was/is 15 minutes, prior to this PR)
2. 404s for tests not found on our internal wpt.stage.*/wpt-api.* instances/endpoints
3. Other weird stuff I'm forgetting, but am too tired to recall; feels like concurrency issues, and hopefully the attached screenshots are helpful.

I think I also want to lessen the frequency of the runs in a separate PR...

We definitely must (I'm looking into it, but would appreciate help from others!) figure out our various timeouts, and try to get test-failures -> job failures -> metrics-publishing errors, etc., understood.

<img width="2032" alt="screen shot 2018-11-29 at 3 21 47 pm" src="https://user-images.githubusercontent.com/387249/49259364-f485ac80-f3ed-11e8-95ce-f7bb75e89018.png">

