### PR TITLE
Add IRC and email alerts for build failures

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,6 +48,13 @@ test ${TARGET_URL} --location us-east-1-linux:Chrome%20Canary --bodies --keepua 
         }
         failure {
           ircNotification('#perftest-alerts')
+          emailext(
+                  attachLog: true,
+                  body: '$BUILD_URL\n\n$FAILED_TESTS',
+                  replyTo: '$DEFAULT_REPLYTO',
+                  subject: '$DEFAULT_SUBJECT',
+                  to: '$DEFAULT_RECIPIENTS')
+          }
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,11 +49,11 @@ test ${TARGET_URL} --location us-east-1-linux:Chrome%20Canary --bodies --keepua 
         failure {
           ircNotification('#perftest-alerts')
           emailext(
-                  attachLog: true,
-                  body: '$BUILD_URL\n\n$FAILED_TESTS',
-                  replyTo: '$DEFAULT_REPLYTO',
-                  subject: '$DEFAULT_SUBJECT',
-                  to: '$DEFAULT_RECIPIENTS')
+            attachLog: true,
+            body: '$BUILD_URL\n\n$FAILED_TESTS',
+            replyTo: '$DEFAULT_REPLYTO',
+            subject: '$DEFAULT_SUBJECT',
+            to: '$DEFAULT_RECIPIENTS')
         }        
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ test ${TARGET_URL} --location us-east-1-linux:Chrome%20Canary --bodies --keepua 
           stash includes: 'wpt.json', name: 'wpt.json'
         }
         failure {
-          ircNotification()
+          ircNotification('#perftest-alerts')
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,8 +54,7 @@ test ${TARGET_URL} --location us-east-1-linux:Chrome%20Canary --bodies --keepua 
                   replyTo: '$DEFAULT_REPLYTO',
                   subject: '$DEFAULT_SUBJECT',
                   to: '$DEFAULT_RECIPIENTS')
-          }
-        }
+        }        
       }
     }
     stage('Submit stats to datadog') {


### PR DESCRIPTION
@davehunt r?  Only partially addresses https://github.com/mozilla/wpt-api/issues/144 - email alerts are easy to add, but due to being 50 single tests, could be catastrophic to our inboxes; if that's not a concern for you, others, I'll go ahead and add it, too.

Cheers.