### PR TITLE
Add (higher) --priority as 1 (rather than 5), for API-initiated tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,10 +33,10 @@ pipeline {
         writeFile([
           file: 'commands.txt',
           encoding: 'UTF-8',
-          text: """test ${TARGET_URL} --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --video --poll --reporter json --label ${TARGET_NAME}.fx.release
-test ${TARGET_URL} --location us-east-1-linux:Firefox%20Nightly --bodies --keepua -r 3 --first --video --poll --reporter json --label ${TARGET_NAME}.fx.nightly
-test ${TARGET_URL} --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --video --poll --reporter json --label ${TARGET_NAME}.chrome.release
-test ${TARGET_URL} --location us-east-1-linux:Chrome%20Canary --bodies --keepua -r 3 --first --video --poll --reporter json --label ${TARGET_NAME}.chrome.canary"""])
+          text: """test ${TARGET_URL} --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --video --priority 1 --poll --reporter json --label ${TARGET_NAME}.fx.release
+test ${TARGET_URL} --location us-east-1-linux:Firefox%20Nightly --bodies --keepua -r 3 --first --video --priority 1 --poll --reporter json --label ${TARGET_NAME}.fx.nightly
+test ${TARGET_URL} --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --video --priority 1 --poll --reporter json --label ${TARGET_NAME}.chrome.release
+test ${TARGET_URL} --location us-east-1-linux:Chrome%20Canary --bodies --keepua -r 3 --first --video --priority 1 --poll --reporter json --label ${TARGET_NAME}.chrome.canary"""])
         sh '/usr/src/app/bin/webpagetest batch commands.txt > "wpt.json"'
       }
       post {
@@ -54,7 +54,7 @@ test ${TARGET_URL} --location us-east-1-linux:Chrome%20Canary --bodies --keepua 
             replyTo: '$DEFAULT_REPLYTO',
             subject: '$DEFAULT_SUBJECT',
             to: '$DEFAULT_RECIPIENTS')
-        }        
+        }
       }
     }
     stage('Submit stats to datadog') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,10 +35,10 @@ pipeline {
         writeFile([
           file: 'commands.txt',
           encoding: 'UTF-8',
-          text: """test ${TARGET_URL} --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --video --medianvideo --priority 1 --poll --reporter json --label ${TARGET_NAME}.fx.release
-test ${TARGET_URL} --location us-east-1-linux:Firefox%20Nightly --bodies --keepua -r 3 --first --video --medianvideo --priority 1 --poll --reporter json --label ${TARGET_NAME}.fx.nightly
-test ${TARGET_URL} --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --video --medianvideo --priority 1 --poll --reporter json --label ${TARGET_NAME}.chrome.release
-test ${TARGET_URL} --location us-east-1-linux:Chrome%20Canary --bodies --keepua -r 3 --first --video --medianvideo --priority 1 --poll --reporter json --label ${TARGET_NAME}.chrome.canary"""])
+          text: """test ${TARGET_URL} --location us-east-1-linux:Firefox --bodies --keepua -r 3 --first --video --medianvideo --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.fx.release
+test ${TARGET_URL} --location us-east-1-linux:Firefox%20Nightly --bodies --keepua -r 3 --first --video --medianvideo --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.fx.nightly
+test ${TARGET_URL} --location us-east-1-linux:Chrome --bodies --keepua -r 3 --first --video --medianvideo --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.chrome.release
+test ${TARGET_URL} --location us-east-1-linux:Chrome%20Canary --bodies --keepua -r 3 --first --video --medianvideo --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.chrome.canary"""])
         sh '/usr/src/app/bin/webpagetest batch commands.txt > "wpt.json"'
       }
       post {


### PR DESCRIPTION
See https://www.webpagetest.org/forums/archive/index.php?thread-12060.html and ```--priority``` here: https://github.com/marcelduran/webpagetest-api/blob/9c4d4d89aa9637319bdc4d170211e19abafafda7/README.md#test-works-for-test-command-only

@davehunt r, thoughts?  @soulgalore 