### PR TITLE
Add 'webpagetest' label to match jobs + nodes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,9 @@
 #!/usr/bin/env groovy
 
 pipeline {
-  agent none
+  agent {
+      label 'webpagetest'
+  }
   libraries {
     lib('fxtest@1.10')
   }
@@ -54,7 +56,7 @@ test ${TARGET_URL} --location us-east-1-linux:Chrome%20Canary --bodies --keepua 
             replyTo: '$DEFAULT_REPLYTO',
             subject: '$DEFAULT_SUBJECT',
             to: '$DEFAULT_RECIPIENTS')
-        }        
+        }
       }
     }
     stage('Submit stats to datadog') {


### PR DESCRIPTION
@davehunt r?

Tested in https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/wpt/job/vimeo/133/console, manually, using Replay.

<img width="1920" alt="screen shot 2018-12-12 at 1 43 24 pm" src="https://user-images.githubusercontent.com/387249/49900653-fdc24080-fe13-11e8-858d-5ee10067abc2.png">


