### PR TITLE
Bump Jenkins timeout (per-job) to 20 minutes, from 15

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
   options {
     ansiColor('xterm')
     timestamps()
-    timeout(time: 15, unit: 'MINUTES')
+    timeout(time: 20, unit: 'MINUTES')
   }
   stages {
     stage('clone') {
@@ -54,7 +54,7 @@ test ${TARGET_URL} --location us-east-1-linux:Chrome%20Canary --bodies --keepua 
             replyTo: '$DEFAULT_REPLYTO',
             subject: '$DEFAULT_SUBJECT',
             to: '$DEFAULT_RECIPIENTS')
-        }        
+        }
       }
     }
     stage('Submit stats to datadog') {


### PR DESCRIPTION
@davehunt r?

We hit this timeout (see attached screenshot) when trying to run the Twitch.tv run[0].

Just FYI, too, I'm going to also play with ```--timeout```, ```--poll 10``` (to change the polling interval -- matches with Wikimedia).  These will be separate PRs.

It's important, I think, to allow for and try to force/pin the ```WebPageTest``` / ```wptagent``` timeout/browser-kill behavior down.

[0] https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/wpt/job/twitch/224/console

<img width="948" alt="screen shot 2018-12-12 at 9 29 37 pm" src="https://user-images.githubusercontent.com/387249/49918161-f07a7580-fe56-11e8-94d8-5b1d2e3947b7.png">
