### PR TITLE
Add Fx-custom pageLoadTime metric

### DIFF
--- a/metrics.json
+++ b/metrics.json
@@ -4,7 +4,7 @@
   {"name": "firstPaint", "description": "Time to First Non-Blank Paint", "unit": "seconds"},
   {"name": "timeToDOMContentFlushed", "description": "timeToDOMContentFlushed", "unit": "milliseconds"},
   {"name": "SpeedIndex", "description": "SpeedIndex", "unit": "seconds"},
-  {"name": "pageLoadTime", "description": "Custom Fx page-load metric", "unit": "seconds"}
+  {"name": "pageLoadTime", "description": "Custom Fx page-load metric", "unit": "seconds"},
   {"name": "bytesInDoc", "description": "Total Bytes in Doc", "unit": "bytes"},
   {"name": "visualComplete", "description": "Time to Visual Complete", "unit": "seconds"},
   {"name": "requestsFull", "description": "Number of HTTP(s) Requests", "unit": "count"}

--- a/metrics.json
+++ b/metrics.json
@@ -4,6 +4,7 @@
   {"name": "firstPaint", "description": "Time to First Non-Blank Paint", "unit": "seconds"},
   {"name": "timeToDOMContentFlushed", "description": "timeToDOMContentFlushed", "unit": "milliseconds"},
   {"name": "SpeedIndex", "description": "SpeedIndex", "unit": "seconds"},
+  {"name": "pageLoadTime", "description": "Custom Fx page-load metric", "unit": "seconds"}
   {"name": "bytesInDoc", "description": "Total Bytes in Doc", "unit": "bytes"},
   {"name": "visualComplete", "description": "Time to Visual Complete", "unit": "seconds"},
   {"name": "requestsFull", "description": "Number of HTTP(s) Requests", "unit": "count"}


### PR DESCRIPTION
This is a corollary to https://github.com/mozilla-services/cloudops-deployment/pull/2824.

Adding in that calculation -- which is the same as Raptor's (see https://bugzilla.mozilla.org/show_bug.cgi?id=1504013#c13), which inspired these PRs.

@davehunt @rwood-moz r?