### PR TITLE
Remove pageLoadTime, as send_to_datadog() isn't set up for it, yet

### DIFF
--- a/metrics.json
+++ b/metrics.json
@@ -6,7 +6,6 @@
   {"name": "timeToDOMContentFlushed", "description": "Time to DOMContentFlushed", "unit": "milliseconds"},
   {"name": "timeToFirstInteractive", "description": "Time to First Interactive", "unit": "milliseconds"},
   {"name": "SpeedIndex", "description": "SpeedIndex", "unit": "seconds"},
-  {"name": "pageLoadTime", "description": "Custom Fx page-load metric", "unit": "seconds"},
   {"name": "bytesInDoc", "description": "Total Bytes in Doc", "unit": "bytes"},
   {"name": "visualComplete", "description": "Time to Visual Complete", "unit": "seconds"},
   {"name": "requestsFull", "description": "Number of HTTP(s) Requests", "unit": "count"}


### PR DESCRIPTION
Sigh; I wasn't thorough enough, and this is causing errors in send_to_datadog.py, because it's expecting it to come from the raw JSON (with schema), rather than being a calculated metric.

```
23:18:07 [yahoo-mail] Running shell script
23:18:07 + python ./send_to_datadog.py wpt.json
23:18:08 Using existing WebPageTest dashboard list
23:18:08 https://mail.yahoo.com - Firefox (64.0)
23:18:08 - TTFB: 426
23:18:08 - render: 700
23:18:08 - firstPaint: 583
23:18:08 - timeToContentfulPaint: None
23:18:08 - timeToDOMContentFlushed: 1545088661677
23:18:08 - timeToFirstInteractive: 0
23:18:08 - SpeedIndex: 797
23:18:08 Traceback (most recent call last):
23:18:08   File "./send_to_datadog.py", line 110, in <module>
23:18:08     main(*sys.argv[1:])
23:18:08   File "./send_to_datadog.py", line 72, in main
23:18:08     value = test["data"]["median"]["firstView"][name]
23:18:08 KeyError: 'pageLoadTime'
```