### PR TITLE
Bump Jenkins-job timeout to 25 min, to help accomodate post-processin…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
   options {
     ansiColor('xterm')
     timestamps()
-    timeout(time: 20, unit: 'MINUTES')
+    timeout(time: 25, unit: 'MINUTES')
   }
   stages {
     stage('clone') {


### PR DESCRIPTION
…g for long-running WPT test runs