### PR TITLE
Rename timeToDOMContentFlushed to its proper metric + name, domConten…

### DIFF
--- a/metrics.json
+++ b/metrics.json
@@ -3,7 +3,7 @@
   {"name": "render", "description": "startRender", "unit": "seconds"},
   {"name": "firstPaint", "description": "Time to First Non-Blank Paint", "unit": "seconds"},
   {"name": "timeToContentfulPaint", "description": "Time to First Contentful Paint", "unit": "milliseconds"},
-  {"name": "timeToDOMContentFlushed", "description": "Time to DOMContentFlushed", "unit": "milliseconds"},
+  {"name": "domContentFlushed", "description": "DOM-content flush time (duration)", "unit": "milliseconds"},
   {"name": "timeToFirstInteractive", "description": "Time to First Interactive", "unit": "milliseconds"},
   {"name": "SpeedIndex", "description": "SpeedIndex", "unit": "seconds"},
   {"name": "bytesInDoc", "description": "Total Bytes in Doc", "unit": "bytes"},


### PR DESCRIPTION
…tFlushed (duration)

This is a direct followup to https://github.com/mozilla-services/cloudops-deployment/pull/2840

/cc @davehunt @rwood-moz just FYI

xref: https://searchfox.org/mozilla-central/rev/76fe4bb385348d3f45bbebcf69ba8c7283dfcec7/testing/raptor/webext/raptor/measure.js#22 and https://searchfox.org/mozilla-central/rev/76fe4bb385348d3f45bbebcf69ba8c7283dfcec7/testing/raptor/webext/raptor/measure.js#191-212, to match the raw value both Raptor and wpt-api are using++