### PR TITLE
Temp. remove storing the median video for all runs; will reintroduce …

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,10 +35,10 @@ pipeline {
         writeFile([
           file: 'commands.txt',
           encoding: 'UTF-8',
-          text: """test ${TARGET_URL} --location us-east-1-linux:Firefox --timeout 900 --bodies --keepua -r 3 --first --median SpeedIndex --video --medianvideo --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.fx.release
-test ${TARGET_URL} --location us-east-1-linux:Firefox%20Nightly --timeout 900 --bodies --keepua -r 3 --first --median SpeedIndex --video --medianvideo --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.fx.nightly
-test ${TARGET_URL} --location us-east-1-linux:Chrome --timeout 900 --bodies --keepua -r 3 --first --median SpeedIndex --video --medianvideo --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.chrome.release
-test ${TARGET_URL} --location us-east-1-linux:Chrome%20Canary --timeout 900 --bodies --keepua -r 3 --first --median SpeedIndex --video --medianvideo --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.chrome.canary"""])
+          text: """test ${TARGET_URL} --location us-east-1-linux:Firefox --timeout 900 --bodies --keepua -r 3 --first --median SpeedIndex --video --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.fx.release
+test ${TARGET_URL} --location us-east-1-linux:Firefox%20Nightly --timeout 900 --bodies --keepua -r 3 --first --median SpeedIndex --video --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.fx.nightly
+test ${TARGET_URL} --location us-east-1-linux:Chrome --timeout 900 --bodies --keepua -r 3 --first --median SpeedIndex --video --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.chrome.release
+test ${TARGET_URL} --location us-east-1-linux:Chrome%20Canary --timeout 900 --bodies --keepua -r 3 --first --median SpeedIndex --video --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.chrome.canary"""])
         sh '/usr/src/app/bin/webpagetest batch commands.txt > "wpt.json"'
       }
       post {


### PR DESCRIPTION
…when infra is sorted (xref: https://github.com/WPO-Foundation/wptagent/issues/231)

See https://github.com/marcelduran/webpagetest-api/tree/9c4d4d89aa9637319bdc4d170211e19abafafda7#test-works-for-test-command-only:

```
-A, --medianvideo: store the video from the median run when capturing video is enabled
```

/cc @davehunt @jbuck @pmeenan, just FYI