### PR TITLE
Remove --video, so we stop trying to saving captured video + filmstrips

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,10 +35,10 @@ pipeline {
         writeFile([
           file: 'commands.txt',
           encoding: 'UTF-8',
-          text: """test ${TARGET_URL} --location us-east-1-linux:Firefox --timeout 900 --bodies --keepua --noimages -r 3 --first --median SpeedIndex --video --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.fx.release
-test ${TARGET_URL} --location us-east-1-linux:Firefox%20Nightly --timeout 900 --bodies --keepua --noimages -r 3 --first --median SpeedIndex --video --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.fx.nightly
-test ${TARGET_URL} --location us-east-1-linux:Chrome --timeout 900 --bodies --keepua --noimages -r 3 --first --median SpeedIndex --video --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.chrome.release
-test ${TARGET_URL} --location us-east-1-linux:Chrome%20Canary --timeout 900 --bodies --keepua --noimages -r 3 --first --median SpeedIndex --video --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.chrome.canary"""])
+          text: """test ${TARGET_URL} --location us-east-1-linux:Firefox --timeout 900 --bodies --keepua --noimages -r 3 --first --median SpeedIndex --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.fx.release
+test ${TARGET_URL} --location us-east-1-linux:Firefox%20Nightly --timeout 900 --bodies --keepua --noimages -r 3 --first --median SpeedIndex --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.fx.nightly
+test ${TARGET_URL} --location us-east-1-linux:Chrome --timeout 900 --bodies --keepua --noimages -r 3 --first --median SpeedIndex --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.chrome.release
+test ${TARGET_URL} --location us-east-1-linux:Chrome%20Canary --timeout 900 --bodies --keepua --noimages -r 3 --first --median SpeedIndex --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.chrome.canary"""])
         sh '/usr/src/app/bin/webpagetest batch commands.txt > "wpt.json"'
       }
       post {


### PR DESCRIPTION
N.B. - we still need my next PR, which removes ```--median SpeedIndex```, as passing that overrides the defaults, as that metric relies entirely, I believe on the video, and needs to retain it (for a bit), post-process, and analyze the test-run video.

See https://www.webpagetest.org/forums/showthread.php?tid=12830&pid=22972#pid22972

/cc @davehunt 