### PR TITLE
Remove response bodies

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,10 +35,10 @@ pipeline {
         writeFile([
           file: 'commands.txt',
           encoding: 'UTF-8',
-          text: """test ${TARGET_URL} --location us-east-1-linux:Firefox --bodies --keepua --noopt --noimages -r 3 --first --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.fx.release
-test ${TARGET_URL} --location us-east-1-linux:Firefox%20Nightly --bodies --keepua  --noopt --noimages -r 3 --first --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.fx.nightly
-test ${TARGET_URL} --location us-east-1-linux:Chrome --bodies --keepua  --noopt --noimages -r 3 --first --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.chrome.release
-test ${TARGET_URL} --location us-east-1-linux:Chrome%20Canary --bodies --keepua  --noopt --noimages -r 3 --first --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.chrome.canary"""])
+          text: """test ${TARGET_URL} --location us-east-1-linux:Firefox --keepua --noopt --noimages -r 3 --first --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.fx.release
+test ${TARGET_URL} --location us-east-1-linux:Firefox%20Nightly --keepua  --noopt --noimages -r 3 --first --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.fx.nightly
+test ${TARGET_URL} --location us-east-1-linux:Chrome --keepua  --noopt --noimages -r 3 --first --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.chrome.release
+test ${TARGET_URL} --location us-east-1-linux:Chrome%20Canary --keepua  --noopt --noimages -r 3 --first --priority 1 --poll 5 --reporter json --label ${TARGET_NAME}.chrome.canary"""])
         sh '/usr/src/app/bin/webpagetest batch commands.txt > "wpt.json"'
       }
       post {

--- a/send_to_datadog.py
+++ b/send_to_datadog.py
@@ -72,6 +72,7 @@ def main(path):
             value = test["data"]["median"]["firstView"][name]
             print(f"- {name}: {value} ({metric['unit']})")
             statsd.gauge(f"wpt.batch.{label}.median.firstView.{name}", value)
+            print(["summary"])
 
     # pprint(tb)
     for item in tbdata.values():


### PR DESCRIPTION
Unfortunately, response bodies for text resources (raw CSS, JavaScript, etc., files) aren't working 100% in Firefox.  I'll work through the issue(s) with Pat Meenan and others, and then we'll re-enable.

I imagine this will save us just a bit of overhead/post-processing time, at least, too.