### PR TITLE
Part 1 of Issue #84: add PUB_WPT_API_KEY to Jenkins' environment block

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ pipeline {
   environment {
     WEB_PAGE_TEST = credentials('WEB_PAGE_TEST')
     WEBPAGETEST_SERVER = "https://${WEB_PAGE_TEST}@wpt-api.stage.mozaws.net/"
+    PUB_WPT_API_KEY = credentials('PUB_WPT_API_KEY')
   }
   options {
     ansiColor('xterm')


### PR DESCRIPTION
This is safe, and is only the first step in https://github.com/mozilla/wpt-api/issues/84 towards public-instance mobile runs called via our Jenkins jobs, but we should be able to iterate quickly.

