### PR TITLE
Allow for median/standardDeviation to be missing from the results

### DIFF
--- a/send_to_telemetry.py
+++ b/send_to_telemetry.py
@@ -38,7 +38,11 @@ def main(path):
             name = metric["name"]
             # now, grab all metrics' values
             for measure in ["median", "standardDeviation"]:
-                sample = test["data"][measure]["firstView"].get(name)
+                sample = None
+                try:
+                    sample = test["data"][measure]["firstView"].get(name)
+                except AttributeError:
+                    pass
                 # sefdefault()s here will return each metric name & value,
                 # or return and set an empty dict
                 if sample is not None:


### PR DESCRIPTION
This patch allows us to ignore when median or standardDeviation are missing from the results. This allows the JSON to be generated, and the following stages to execute, but will not alert us to the issue. I think this is fine, as the schema allows for these to be missing, but if the cause is a crash that we should be aware of then perhaps we need a way to be notified of such issues.