### PR TITLE
Work around issues with latest Jenkins and plugins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,9 +23,9 @@ pipeline {
       steps {
         checkout([
           $class: 'GitSCM',
-          branches: [[name: 'master']],
+          branches: [[name: 'remove-entrypoint']],
           extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'webpagetest-api']],
-          userRemoteConfigs: [[url: 'https://github.com/marcelduran/webpagetest-api']]])
+          userRemoteConfigs: [[url: 'https://github.com/davehunt/webpagetest-api']]])
       }
     }
     stage('Run WebPageTest (command-line API)') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,7 +91,7 @@ test ${TARGET_URL} --location us-east-1-linux:Chrome%20Canary --keepua  --noopt 
         subject: '$DEFAULT_SUBJECT',
         to: '$DEFAULT_RECIPIENTS')
     }
-    always {
+    cleanup {
       deleteDir()
     }
   }


### PR DESCRIPTION
The ENTRYPOINT in the Dockerfile for webpagetest-api is causing issues with the latest version of Jenkins and docker workflow plugins. I've forked the repo and removed the entrypoint, and reference the fork/branch here. It seems to resolve our issues.