### PR TITLE
Use standard 36-character UUID representation for telemetry

### DIFF
--- a/send_to_telemetry.py
+++ b/send_to_telemetry.py
@@ -81,7 +81,7 @@ def main(path):
             validate(asdict(result), schema)
 
         # send to telemetry
-        wpt_run_uuid = uuid.uuid4().hex
+        wpt_run_uuid = str(uuid.uuid4())
         telemetry_url = f"https://incoming.telemetry.mozilla.org/submit/webpagetest/webpagetest-run/1/{wpt_run_uuid}"
         results_json = json.dumps(asdict(result))
         r = requests.post(


### PR DESCRIPTION
The new telemetry pipeline in GCP is more strict about requiring that
submissions include a valid UUID as the document_id in the URI.
Specifically, the pipeline requires the standard 36-character representation
that includes dashes.

Currently, wpt pings are identified as invalid and sent to error output in the
GCP telemetry pipeline due to using 32-character UUIDs.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1597217